### PR TITLE
Add search command test

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -253,7 +253,7 @@ Step 2. The user executes `add n/Ui bug d/Displays wrongly the information s/tod
 - state: **todo**
 - tag: **Ui.java**
 
-Step 3. When there are a lot of bugs in the tracker, it is difficult for the user to look for the particular bug. The user wants to see the information of the above bug. Then, the user executes `search k/Ui bug`. This results in the information of all the bugs of which name or description or tag contains `Ui bug` as a substring displays in the tracker.
+Step 3. When there are a lot of bugs in the tracker, it is difficult for the user to look for the particular bug. The user wants to see the information of the above bug. Then, the user executes `search q/Ui bug`. This results in the information of all the bugs of which name or description or tag contains `Ui bug` as a substring displays in the tracker.
 
 **Note that the keyword is case-insensitive**
 

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -42,8 +42,8 @@ public class SearchCommandTest {
         assertTrue(searchFirstCommand.equals(searchFirstCommand));
 
         // same values -> returns true
-        SearchCommand findFirstCommandCopy = new SearchCommand(firstPredicate);
-        assertTrue(searchFirstCommand.equals(findFirstCommandCopy));
+        SearchCommand searchFirstCommandCopy = new SearchCommand(firstPredicate);
+        assertTrue(searchFirstCommand.equals(searchFirstCommandCopy));
 
         // different types -> returns false
         assertFalse(searchFirstCommand.equals(1));

--- a/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/SearchCommandTest.java
@@ -1,0 +1,114 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_BUGS_LISTED_OVERVIEW;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.TypicalBugs.BUGFOUR;
+import static seedu.address.testutil.TypicalBugs.BUGONE;
+import static seedu.address.testutil.TypicalBugs.BUGSEVEN;
+import static seedu.address.testutil.TypicalBugs.BUGTHREE;
+import static seedu.address.testutil.TypicalBugs.getTypicalKanBugTracker;
+
+import java.util.Arrays;
+import java.util.Collections;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.bug.BugContainsQueryStringPredicate;
+
+/**
+ * Contains integration tests (interaction with the Model) for {@code SearchCommand}.
+ */
+public class SearchCommandTest {
+    private Model model = new ModelManager(getTypicalKanBugTracker(), new UserPrefs());
+    private Model expectedModel = new ModelManager(getTypicalKanBugTracker(), new UserPrefs());
+
+    @Test
+    public void equals() {
+        BugContainsQueryStringPredicate firstPredicate =
+                new BugContainsQueryStringPredicate("first");
+        BugContainsQueryStringPredicate secondPredicate =
+                new BugContainsQueryStringPredicate("second");
+
+        SearchCommand searchFirstCommand = new SearchCommand(firstPredicate);
+        SearchCommand searchSecondCommand = new SearchCommand(secondPredicate);
+
+        // same object -> returns true
+        assertTrue(searchFirstCommand.equals(searchFirstCommand));
+
+        // same values -> returns true
+        SearchCommand findFirstCommandCopy = new SearchCommand(firstPredicate);
+        assertTrue(searchFirstCommand.equals(findFirstCommandCopy));
+
+        // different types -> returns false
+        assertFalse(searchFirstCommand.equals(1));
+
+        // null -> returns false
+        assertFalse(searchFirstCommand.equals(null));
+
+        // different bug -> returns false
+        assertFalse(searchFirstCommand.equals(searchSecondCommand));
+    }
+
+    @Test
+    public void execute_emptyData_noBugFound() {
+        String expectedMessage = String.format(MESSAGE_BUGS_LISTED_OVERVIEW, 0);
+        BugContainsQueryStringPredicate predicate = preparePredicate("No data");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredBugList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Collections.emptyList(), model.getFilteredBugList());
+    }
+
+    @Test
+    public void execute_oneKeywordQueryString_oneBugFound() {
+        String expectedMessage = String.format(MESSAGE_BUGS_LISTED_OVERVIEW, 1);
+        BugContainsQueryStringPredicate predicate = preparePredicate("Alice");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredBugList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BUGONE), model.getFilteredBugList());
+    }
+
+    @Test
+    public void execute_multipleKeywordsQueryString_oneBugFound() {
+        String expectedMessage = String.format(MESSAGE_BUGS_LISTED_OVERVIEW, 1);
+        BugContainsQueryStringPredicate predicate = preparePredicate("Carl Kurz");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredBugList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BUGTHREE), model.getFilteredBugList());
+    }
+
+    @Test
+    public void execute_oneKeywordQueryString_multipleBugsFound() {
+        String expectedMessage = String.format(MESSAGE_BUGS_LISTED_OVERVIEW, 3);
+        BugContainsQueryStringPredicate predicate = preparePredicate("street");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredBugList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BUGTHREE, BUGFOUR, BUGSEVEN), model.getFilteredBugList());
+    }
+
+    @Test
+    public void execute_mixedCaseQueryString_multipleBugsFound() {
+        String expectedMessage = String.format(MESSAGE_BUGS_LISTED_OVERVIEW, 3);
+        BugContainsQueryStringPredicate predicate = preparePredicate("STrEeT");
+        SearchCommand command = new SearchCommand(predicate);
+        expectedModel.updateFilteredBugList(predicate);
+        assertCommandSuccess(command, model, expectedMessage, expectedModel);
+        assertEquals(Arrays.asList(BUGTHREE, BUGFOUR, BUGSEVEN), model.getFilteredBugList());
+    }
+
+    /**
+     * Parses {@code userInput} into a {@code NameContainsKeywordsPredicate}.
+     */
+    private BugContainsQueryStringPredicate preparePredicate(String userInput) {
+        return new BugContainsQueryStringPredicate(userInput);
+    }
+}

--- a/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
+++ b/src/test/java/seedu/address/logic/parser/SearchCommandParserTest.java
@@ -1,0 +1,32 @@
+package seedu.address.logic.parser;
+
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseFailure;
+import static seedu.address.logic.parser.CommandParserTestUtil.assertParseSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.SearchCommand;
+import seedu.address.model.bug.BugContainsQueryStringPredicate;
+
+
+public class SearchCommandParserTest {
+    private SearchCommandParser parser = new SearchCommandParser();
+    @Test
+    public void parse_emptyArg_throwsParseException() {
+        assertParseFailure(parser, "     ", String.format(MESSAGE_INVALID_COMMAND_FORMAT, SearchCommand.MESSAGE_USAGE));
+    }
+
+    @Test
+    public void parse_valid_returnsSearchCommand() {
+        // no leading and trailing whitespaces
+        SearchCommand expectedSearchCommand = new SearchCommand(new BugContainsQueryStringPredicate("Ui bug"));
+        assertParseSuccess(parser, "search q/Ui bug", expectedSearchCommand);
+
+        // multiple whitespaces between keywords
+        assertParseSuccess(parser, " search  q/ Ui bug     ", expectedSearchCommand);
+
+        // multiple repetitive prefixes
+        assertParseSuccess(parser, " search q/Skip q/Skip q/Ui bug", expectedSearchCommand);
+    }
+}

--- a/src/test/java/seedu/address/model/bug/BugContainsQueryStringPredicateTest.java
+++ b/src/test/java/seedu/address/model/bug/BugContainsQueryStringPredicateTest.java
@@ -1,0 +1,110 @@
+package seedu.address.model.bug;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.testutil.BugBuilder;
+
+public class BugContainsQueryStringPredicateTest {
+
+    @Test
+    public void equals() {
+        String firstPredicateQueryString = "first";
+        String secondPredicateQueryString = "second";
+
+        BugContainsQueryStringPredicate firstPredicate =
+                new BugContainsQueryStringPredicate(firstPredicateQueryString);
+        BugContainsQueryStringPredicate secondPredicate =
+                new BugContainsQueryStringPredicate(secondPredicateQueryString);
+
+        // same object -> returns true
+        assertTrue(firstPredicate.equals(firstPredicate));
+
+        // same values -> returns true
+        BugContainsQueryStringPredicate firstPredicateCopy =
+                new BugContainsQueryStringPredicate(firstPredicateQueryString);
+        assertTrue(firstPredicate.equals(firstPredicateCopy));
+
+        // different types -> returns false
+        assertFalse(firstPredicate.equals(1));
+
+        // null -> returns false
+        assertFalse(firstPredicate.equals(null));
+
+        // different bug -> returns false
+        assertFalse(firstPredicate.equals(secondPredicate));
+    }
+
+    @Test
+    public void test_nameContainsQueryString_returnsTrue() {
+        // One keyword query-string
+        BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("message");
+        assertTrue(predicate.test(new BugBuilder().withName("Print wrong messages").build()));
+
+        // One query-string
+        predicate = new BugContainsQueryStringPredicate("Ui display");
+        assertTrue(predicate.test(new BugBuilder().withName("Ui display").build()));
+
+        // Mixed-case keyword query-string
+        predicate = new BugContainsQueryStringPredicate("ui");
+        assertTrue(predicate.test(new BugBuilder().withName("Ui Bug").build()));
+
+        // Mixed-case query-string
+        predicate = new BugContainsQueryStringPredicate("uI bUG");
+        assertTrue(predicate.test(new BugBuilder().withName("Ui Bug").build()));
+    }
+
+    @Test
+    public void test_descriptionContainsQueryString_returnsTrue() {
+        // One keyword query-string
+        BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("message");
+        assertTrue(predicate.test(new BugBuilder().withDescription("Print wrong messages").build()));
+
+        // One query-string
+        predicate = new BugContainsQueryStringPredicate("Ui display");
+        assertTrue(predicate.test(new BugBuilder().withDescription("Ui display").build()));
+
+        // Mixed-case keyword query-string
+        predicate = new BugContainsQueryStringPredicate("ui");
+        assertTrue(predicate.test(new BugBuilder().withDescription("Ui Bug").build()));
+
+        // Mixed-case query-string
+        predicate = new BugContainsQueryStringPredicate("uI bUG");
+        assertTrue(predicate.test(new BugBuilder().withDescription("Ui Bug").build()));
+    }
+
+    @Test
+    public void test_tagContainsQueryString_returnsTrue() {
+        // One keyword query-string
+        String[] tags = {"Ui", "frontend", "JavaFX"};
+        BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("frontend");
+        assertTrue(predicate.test(new BugBuilder().withTags(tags).build()));
+
+        // Mixed-case keyword query-string
+        predicate = new BugContainsQueryStringPredicate("uI");
+        assertTrue(predicate.test(new BugBuilder().withTags(tags).build()));
+
+        predicate = new BugContainsQueryStringPredicate("Java");
+        assertTrue(predicate.test(new BugBuilder().withTags(tags).build()));
+
+        predicate = new BugContainsQueryStringPredicate("fx");
+        assertTrue(predicate.test(new BugBuilder().withTags(tags).build()));
+    }
+
+    @Test
+    public void test_nameDoesNotContainQueryString_returnsFalse() {
+        // Non-matching keyword query-string
+        BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("Ui");
+        assertFalse(predicate.test(new BugBuilder().withName("Print wrong messages").build()));
+    }
+
+    @Test
+    public void test_descriptionDoesNotContainQueryString_returnsFalse() {
+        // Non-matching keyword query-string
+        String[] tags = {"Ui", "frontend", "JavaFX"};
+        BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("backend");
+        assertFalse(predicate.test(new BugBuilder().withTags(tags).build()));
+    }
+}

--- a/src/test/java/seedu/address/model/bug/BugContainsQueryStringPredicateTest.java
+++ b/src/test/java/seedu/address/model/bug/BugContainsQueryStringPredicateTest.java
@@ -43,15 +43,15 @@ public class BugContainsQueryStringPredicateTest {
         BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("message");
         assertTrue(predicate.test(new BugBuilder().withName("Print wrong messages").build()));
 
-        // One query-string
+        // Multiple keywords query-string
         predicate = new BugContainsQueryStringPredicate("Ui display");
         assertTrue(predicate.test(new BugBuilder().withName("Ui display").build()));
 
-        // Mixed-case keyword query-string
+        // One mixed-case keyword query-string
         predicate = new BugContainsQueryStringPredicate("ui");
         assertTrue(predicate.test(new BugBuilder().withName("Ui Bug").build()));
 
-        // Mixed-case query-string
+        // Multiple mixed-case keywords query-string
         predicate = new BugContainsQueryStringPredicate("uI bUG");
         assertTrue(predicate.test(new BugBuilder().withName("Ui Bug").build()));
     }
@@ -62,15 +62,15 @@ public class BugContainsQueryStringPredicateTest {
         BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("message");
         assertTrue(predicate.test(new BugBuilder().withDescription("Print wrong messages").build()));
 
-        // One query-string
+        // Multiple keywords query-string
         predicate = new BugContainsQueryStringPredicate("Ui display");
         assertTrue(predicate.test(new BugBuilder().withDescription("Ui display").build()));
 
-        // Mixed-case keyword query-string
+        // One mixed-case keyword query-string
         predicate = new BugContainsQueryStringPredicate("ui");
         assertTrue(predicate.test(new BugBuilder().withDescription("Ui Bug").build()));
 
-        // Mixed-case query-string
+        // Multiple mixed-case keywords query-string
         predicate = new BugContainsQueryStringPredicate("uI bUG");
         assertTrue(predicate.test(new BugBuilder().withDescription("Ui Bug").build()));
     }
@@ -82,7 +82,7 @@ public class BugContainsQueryStringPredicateTest {
         BugContainsQueryStringPredicate predicate = new BugContainsQueryStringPredicate("frontend");
         assertTrue(predicate.test(new BugBuilder().withTags(tags).build()));
 
-        // Mixed-case keyword query-string
+        // Multiple keywords query-string
         predicate = new BugContainsQueryStringPredicate("uI");
         assertTrue(predicate.test(new BugBuilder().withTags(tags).build()));
 


### PR DESCRIPTION
Closes #129 
In this PR, I create `SearchCommandTest`, `SearchCommandParserTest` and `BugContainsQueryStringPredicateTest` to write tests to the functionalities of the search command and also check user's input validity.