### PR TITLE
Add move by state and edit by state

### DIFF
--- a/src/main/java/seedu/address/logic/commands/DeleteByStateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/DeleteByStateCommand.java
@@ -39,8 +39,14 @@ public class DeleteByStateCommand extends DeleteCommand {
 
     @Override
     public boolean equals(Object other) {
-        return other == this // short circuit if same object
-                   || (other instanceof DeleteCommand // instanceof handles nulls
-                           && targetIndex.equals(((DeleteCommand) other).targetIndex)); // state check
+        if (other == this) {
+            return true; // short circuit if same object
+        } else if (!(other instanceof DeleteByStateCommand)) {
+            return false; // different object
+        }
+        DeleteByStateCommand d = (DeleteByStateCommand) other;
+
+        return targetState.equals(d.targetState)
+            && targetIndex.equals(d.targetIndex);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/EditByStateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditByStateCommand.java
@@ -1,6 +1,15 @@
 package seedu.address.logic.commands;
 
+import static java.util.Objects.requireNonNull;
+import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BUGS;
+
+import java.util.List;
+
+import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.Model;
+import seedu.address.model.bug.Bug;
 import seedu.address.model.bug.State;
 
 public class EditByStateCommand extends EditCommand {
@@ -16,5 +25,44 @@ public class EditByStateCommand extends EditCommand {
         this.targetState = targetState;
     }
 
-    
+    @Override
+    public CommandResult execute(Model model) throws CommandException {
+        requireNonNull(model);
+        List<Bug> lastShownList = model.getFilteredBugListByState(targetState);
+
+        if (index.getZeroBased() >= lastShownList.size()) {
+            throw new CommandException(Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX);
+        }
+
+        Bug bugToEdit = lastShownList.get(index.getZeroBased());
+        Bug editedBug = createEditedBug(bugToEdit, editBugDescriptor);
+
+        if (!bugToEdit.isSameBug(editedBug) && model.hasBug(editedBug)) {
+            throw new CommandException(MESSAGE_DUPLICATE_BUG);
+        }
+
+        model.setBug(bugToEdit, editedBug);
+        model.updateFilteredBugList(PREDICATE_SHOW_ALL_BUGS);
+        return new CommandResult(String.format(MESSAGE_EDIT_BUG_SUCCESS, editedBug));
+    }
+
+    @Override
+    public boolean equals(Object other) {
+        // short circuit if same object
+        if (other == this) {
+            return true;
+        }
+
+        // instanceof handles nulls
+        if (!(other instanceof EditByStateCommand)) {
+            return false;
+        }
+
+        // state check
+        EditByStateCommand e = (EditByStateCommand) other;
+        return index.equals(e.index)
+                   && editBugDescriptor.equals(e.editBugDescriptor)
+                   && targetState.equals(e.targetState);
+    }
+
 }

--- a/src/main/java/seedu/address/logic/commands/EditByStateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditByStateCommand.java
@@ -1,0 +1,20 @@
+package seedu.address.logic.commands;
+
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.bug.State;
+
+public class EditByStateCommand extends EditCommand {
+
+    private State targetState;
+
+    /**
+     * @param index of the bug in the filtered bug list to edit
+     * @param editBugDescriptor details to edit the bug with
+     */
+    public EditByStateCommand(Index index, EditBugDescriptor editBugDescriptor, State targetState) {
+        super(index, editBugDescriptor);
+        this.targetState = targetState;
+    }
+
+    
+}

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COLUMN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
@@ -42,7 +43,8 @@ public class EditCommand extends Command {
             + "[" + PREFIX_STATE + "STATE] "
             + "[" + PREFIX_DESCRIPTION + "DESCRIPTION] "
             + "[" + PREFIX_PRIORITY + "PRIORITY] "
-            + "[" + PREFIX_TAG + "TAG]...\n"
+            + "[" + PREFIX_TAG + "TAG]"
+            + "[" + PREFIX_COLUMN + "STATE]\n"
             + "Example: " + COMMAND_WORD + " 1 "
             + PREFIX_STATE + "todo";
 
@@ -90,7 +92,7 @@ public class EditCommand extends Command {
      * Creates and returns a {@code Bug} with the details of {@code bugToEdit}
      * edited with {@code editBugDescriptor}.
      */
-    private static Bug createEditedBug(Bug bugToEdit, EditBugDescriptor editBugDescriptor) {
+    protected static Bug createEditedBug(Bug bugToEdit, EditBugDescriptor editBugDescriptor) {
         assert bugToEdit != null;
 
         Name updatedName = editBugDescriptor.getName().orElse(bugToEdit.getName());

--- a/src/main/java/seedu/address/logic/commands/KanbanCommand.java
+++ b/src/main/java/seedu/address/logic/commands/KanbanCommand.java
@@ -1,12 +1,13 @@
 package seedu.address.logic.commands;
 
-import seedu.address.logic.commands.exceptions.CommandException;
 import seedu.address.model.Model;
 
 public class KanbanCommand extends Command {
+
     public static final String COMMAND_WORD = "kanban";
+
     @Override
-    public CommandResult execute(Model model) throws CommandException {
+    public CommandResult execute(Model model) {
         return new CommandResult("", false, false, true);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/MoveByStateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveByStateCommand.java
@@ -4,6 +4,7 @@ import static java.util.Objects.requireNonNull;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BUGS;
 
 import java.util.List;
+
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;

--- a/src/main/java/seedu/address/logic/commands/MoveByStateCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveByStateCommand.java
@@ -1,11 +1,9 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
-import static seedu.address.logic.parser.CliSyntax.PREFIX_STATE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BUGS;
 
 import java.util.List;
-
 import seedu.address.commons.core.Messages;
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.exceptions.CommandException;
@@ -13,36 +11,22 @@ import seedu.address.model.Model;
 import seedu.address.model.bug.Bug;
 import seedu.address.model.bug.State;
 
-public class MoveCommand extends Command {
-
-    public static final String COMMAND_WORD = "move";
-    public static final String MESSAGE_USAGE = COMMAND_WORD + ": Move the bug to new state identified "
-            + "by the index number used in the displayed bug list. \n"
-            + "Parameters: INDEX (must be a positive integer) "
-            + PREFIX_STATE + "STATE "
-            + "Example: " + COMMAND_WORD + " 1 "
-            + PREFIX_STATE + "done";
-
-    public static final String MESSAGE_MOVE_BUG_SUCCESS = "Moved Bug: %1$s";
-
-    protected final Index index;
-    protected final State state;
+public class MoveByStateCommand extends MoveCommand {
+    private State tagetState;
 
     /**
      * @param index of the bug in the filtered bug list to edit
      * @param state details to edit the bug with
      */
-    public MoveCommand(Index index, State state) {
-        requireNonNull(index);
-        requireNonNull(state);
-        this.index = index;
-        this.state = state;
+    public MoveByStateCommand(Index index, State state, State tagetState) {
+        super(index, state);
+        this.tagetState = tagetState;
     }
 
     @Override
     public CommandResult execute(Model model) throws CommandException {
         requireNonNull(model);
-        List<Bug> lastShownList = model.getFilteredBugList();
+        List<Bug> lastShownList = model.getFilteredBugListByState(tagetState);
 
         if (index.getZeroBased() >= lastShownList.size()) {
             throw new CommandException(Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX);
@@ -55,12 +39,6 @@ public class MoveCommand extends Command {
         model.updateFilteredBugList(PREDICATE_SHOW_ALL_BUGS);
 
         return new CommandResult(String.format(MESSAGE_MOVE_BUG_SUCCESS, movedBug));
-    }
-
-    protected static Bug createMovedBug(Bug bugToMove, State destination) {
-        assert bugToMove != null;
-        return new Bug(bugToMove.getName(), destination, bugToMove.getDescription(),
-                bugToMove.getTags(), bugToMove.getPriority());
     }
 
     @Override
@@ -76,8 +54,9 @@ public class MoveCommand extends Command {
         }
 
         // state check
-        MoveCommand e = (MoveCommand) other;
+        MoveByStateCommand e = (MoveByStateCommand) other;
         return index.equals(e.index)
-                && state.equals(e.state);
+                   && state.equals(e.state)
+                   && tagetState.equals(e.tagetState);
     }
 }

--- a/src/main/java/seedu/address/logic/commands/MoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveCommand.java
@@ -1,6 +1,7 @@
 package seedu.address.logic.commands;
 
 import static java.util.Objects.requireNonNull;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COLUMN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATE;
 import static seedu.address.model.Model.PREDICATE_SHOW_ALL_BUGS;
 
@@ -20,7 +21,8 @@ public class MoveCommand extends Command {
             + "by the index number used in the displayed bug list. \n"
             + "Parameters: INDEX (must be a positive integer) "
             + PREFIX_STATE + "STATE "
-            + "Example: " + COMMAND_WORD + " 1 "
+            + "[" + PREFIX_COLUMN + "STATE]"
+            + "Example: " + COMMAND_WORD
             + PREFIX_STATE + "done";
 
     public static final String MESSAGE_MOVE_BUG_SUCCESS = "Moved Bug: %1$s";

--- a/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/DeleteCommandParser.java
@@ -26,8 +26,8 @@ public class DeleteCommandParser implements Parser<DeleteCommand> {
             ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_COLUMN);
             Index index = ParserUtil.parseIndex(argMultimap.getPreamble());
             if (arePrefixesPresent(argMultimap, PREFIX_COLUMN)) {
-                State column = ParserUtil.parseState(argMultimap.getValue(PREFIX_COLUMN).get());
-                return new DeleteByStateCommand(index, column);
+                State targetState = ParserUtil.parseState(argMultimap.getValue(PREFIX_COLUMN).get());
+                return new DeleteByStateCommand(index, targetState);
             }
 
             return new DeleteCommand(index);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -2,6 +2,7 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COLUMN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_DESCRIPTION;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_NAME;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_PRIORITY;
@@ -14,10 +15,12 @@ import java.util.Optional;
 import java.util.Set;
 
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.EditByStateCommand;
 import seedu.address.logic.commands.EditCommand;
 import seedu.address.logic.commands.EditCommand.EditBugDescriptor;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.bug.Priority;
+import seedu.address.model.bug.State;
 import seedu.address.model.tag.Tag;
 
 /**
@@ -62,6 +65,10 @@ public class EditCommandParser implements Parser<EditCommand> {
 
         if (!editBugDescriptor.isAnyFieldEdited()) {
             throw new ParseException(EditCommand.MESSAGE_NOT_EDITED);
+        }
+        if (argMultimap.getValue(PREFIX_COLUMN).isPresent()) {
+            State targetState = ParserUtil.parseState(argMultimap.getValue(PREFIX_COLUMN).get());
+            return new EditByStateCommand(index, editBugDescriptor, targetState);
         }
 
         return new EditCommand(index, editBugDescriptor);

--- a/src/main/java/seedu/address/logic/parser/MoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MoveCommandParser.java
@@ -6,6 +6,7 @@ import static seedu.address.logic.parser.CliSyntax.PREFIX_COLUMN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATE;
 
 import java.util.stream.Stream;
+
 import seedu.address.commons.core.index.Index;
 import seedu.address.logic.commands.MoveByStateCommand;
 import seedu.address.logic.commands.MoveCommand;

--- a/src/main/java/seedu/address/logic/parser/MoveCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/MoveCommandParser.java
@@ -2,11 +2,12 @@ package seedu.address.logic.parser;
 
 import static java.util.Objects.requireNonNull;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_COMMAND_FORMAT;
+import static seedu.address.logic.parser.CliSyntax.PREFIX_COLUMN;
 import static seedu.address.logic.parser.CliSyntax.PREFIX_STATE;
 
 import java.util.stream.Stream;
-
 import seedu.address.commons.core.index.Index;
+import seedu.address.logic.commands.MoveByStateCommand;
 import seedu.address.logic.commands.MoveCommand;
 import seedu.address.logic.parser.exceptions.ParseException;
 import seedu.address.model.bug.State;
@@ -23,7 +24,7 @@ public class MoveCommandParser implements Parser<MoveCommand> {
     public MoveCommand parse(String args) throws ParseException {
         requireNonNull(args);
         ArgumentMultimap argMultimap =
-                ArgumentTokenizer.tokenize(args, PREFIX_STATE);
+                ArgumentTokenizer.tokenize(args, PREFIX_STATE, PREFIX_COLUMN);
 
         Index index;
 
@@ -39,6 +40,10 @@ public class MoveCommandParser implements Parser<MoveCommand> {
 
         State state = ParserUtil.parseState(argMultimap.getValue(PREFIX_STATE).get());
 
+        if (argMultimap.getValue(PREFIX_COLUMN).isPresent()) {
+            State targetState = ParserUtil.parseState(argMultimap.getValue(PREFIX_COLUMN).get());
+            return new MoveByStateCommand(index, state, targetState);
+        }
         return new MoveCommand(index, state);
     }
 

--- a/src/test/java/seedu/address/logic/commands/AddCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/AddCommandTest.java
@@ -47,7 +47,6 @@ public class AddCommandTest {
         Bug validBug = new BugBuilder().build();
         AddCommand addCommand = new AddCommand(validBug);
         ModelStub modelStub = new ModelStubWithBug(validBug);
-
         assertThrows(CommandException.class, AddCommand.MESSAGE_DUPLICATE_BUG, () -> addCommand.execute(modelStub));
     }
 

--- a/src/test/java/seedu/address/logic/commands/DeleteByStateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/DeleteByStateCommandTest.java
@@ -1,0 +1,74 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showBugAtIndex;
+import static seedu.address.testutil.TypicalBugs.getTypicalKanBugTracker;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BUG;
+import static seedu.address.testutil.TypicalIndexes.INDEX_THIRD_BUG;
+
+import org.junit.jupiter.api.Test;
+
+import javafx.collections.ObservableList;
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.bug.Bug;
+import seedu.address.model.bug.State;
+
+public class DeleteByStateCommandTest {
+    private Model model = new ModelManager(getTypicalKanBugTracker(), new UserPrefs());
+
+    @Test
+    public void execute_invalidIndexUnfilteredList_throwsCommandException() {
+        ObservableList<Bug> todoList = model.getFilteredBugListByState(new State("todo"));
+        Index outOfBoundIndex = Index.fromOneBased(todoList.size() + 1);
+        DeleteByStateCommand deleteCommand = new DeleteByStateCommand(outOfBoundIndex, new State("todo"));
+
+        assertCommandFailure(deleteCommand, model, Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_validIndexFilteredListTodoState_success() {
+        showBugAtIndex(model, INDEX_FIRST_BUG);
+
+        Bug bugToDelete = model.getFilteredBugListByState(new State("todo")).get(INDEX_FIRST_BUG.getZeroBased());
+        DeleteByStateCommand deleteCommand = new DeleteByStateCommand(INDEX_FIRST_BUG, new State("todo"));
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_BUG_SUCCESS, bugToDelete);
+
+        Model expectedModel = new ModelManager(model.getKanBugTracker(), new UserPrefs());
+        expectedModel.deleteBug(bugToDelete);
+        showNoBug(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void execute_validIndexFilteredListDoneState_success() {
+        showBugAtIndex(model, INDEX_THIRD_BUG);
+
+        Bug bugToDelete = model.getFilteredBugListByState(new State("done")).get(INDEX_FIRST_BUG.getZeroBased());
+        DeleteByStateCommand deleteCommand = new DeleteByStateCommand(INDEX_FIRST_BUG, new State("done"));
+
+        String expectedMessage = String.format(DeleteCommand.MESSAGE_DELETE_BUG_SUCCESS, bugToDelete);
+
+        Model expectedModel = new ModelManager(model.getKanBugTracker(), new UserPrefs());
+        expectedModel.deleteBug(bugToDelete);
+        showNoBug(expectedModel);
+
+        assertCommandSuccess(deleteCommand, model, expectedMessage, expectedModel);
+    }
+
+    /**
+     * Updates {@code model}'s filtered list to show no one.
+     */
+    private void showNoBug(Model model) {
+        model.updateFilteredBugList(p -> false);
+
+        assertTrue(model.getFilteredBugList().isEmpty());
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
@@ -3,7 +3,11 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX;
-import static seedu.address.logic.commands.CommandTestUtil.*;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_HOMEPAGE;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_PARSER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_HOMEPAGE;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_BUG1;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBugs.getTypicalKanBugTracker;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BUG;
@@ -51,7 +55,8 @@ public class EditByStateCommandTest {
         final EditByStateCommand standardCommand = new EditByStateCommand(INDEX_FIRST_BUG,
                             DESC_PARSER, VALID_STATE_BUG1);
         EditCommand.EditBugDescriptor copyDescriptor = new EditCommand.EditBugDescriptor(DESC_PARSER);
-        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG, copyDescriptor, new State("todo"));
+        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG, copyDescriptor,
+            new State("todo"));
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true

--- a/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
@@ -55,8 +55,8 @@ public class EditByStateCommandTest {
         final EditByStateCommand standardCommand = new EditByStateCommand(INDEX_FIRST_BUG,
                             DESC_PARSER, VALID_STATE_BUG1);
         EditCommand.EditBugDescriptor copyDescriptor = new EditCommand.EditBugDescriptor(DESC_PARSER);
-        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG, copyDescriptor,
-            new State("todo"));
+        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG,
+            copyDescriptor, new State("todo"));
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true

--- a/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
@@ -1,0 +1,89 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_HOMEPAGE;
+import static seedu.address.logic.commands.CommandTestUtil.DESC_PARSER;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_HOMEPAGE;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.testutil.Assert.assertThrows;
+import static seedu.address.testutil.TypicalBugs.getTypicalKanBugTracker;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BUG;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BUG;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.logic.commands.exceptions.CommandException;
+import seedu.address.model.KanBugTracker;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.bug.Bug;
+import seedu.address.model.bug.State;
+import seedu.address.testutil.BugBuilder;
+import seedu.address.testutil.EditBugDescriptorBuilder;
+
+public class EditByStateCommandTest {
+    private Model model = new ModelManager(getTypicalKanBugTracker(), new UserPrefs());
+
+    @Test
+    public void executeIncorrectTargetStateFailure() {
+        EditByStateCommand editByStateCommandBacklog = new EditByStateCommand(INDEX_SECOND_BUG,
+            new EditBugDescriptorBuilder().withName(VALID_NAME_HOMEPAGE).build(), new State("backlog"));
+        assertThrows(CommandException.class, MESSAGE_INVALID_BUG_DISPLAYED_INDEX, ()-> editByStateCommandBacklog
+                                                                                           .execute(model));
+        EditByStateCommand editByStateCommandOngoing = new EditByStateCommand(INDEX_SECOND_BUG,
+            new EditBugDescriptorBuilder().withName(VALID_NAME_HOMEPAGE).build(), new State("done"));
+        assertThrows(CommandException.class, MESSAGE_INVALID_BUG_DISPLAYED_INDEX, ()-> editByStateCommandOngoing
+                                                                                           .execute(model));
+    }
+
+    @Test
+    public void execute_allFieldsSpecifiedUnfilteredList_success() {
+        Bug editedBug = new BugBuilder().build();
+        EditCommand.EditBugDescriptor descriptor = new EditBugDescriptorBuilder(editedBug).build();
+        EditByStateCommand editCommand = new EditByStateCommand(INDEX_FIRST_BUG, descriptor, new State("todo"));
+
+        String expectedMessage = String.format(EditCommand.MESSAGE_EDIT_BUG_SUCCESS, editedBug);
+
+        Model expectedModel = new ModelManager(new KanBugTracker(model.getKanBugTracker()), new UserPrefs());
+        expectedModel.setBug(model.getFilteredBugListByState(new State("todo")).get(0), editedBug);
+
+        assertCommandSuccess(editCommand, model, expectedMessage, expectedModel);
+    }
+
+    @Test
+    public void equals() {
+        final EditByStateCommand standardCommand = new EditByStateCommand(INDEX_FIRST_BUG,
+                            DESC_PARSER, new State("todo"));
+
+        // same values -> returns true
+        EditCommand.EditBugDescriptor copyDescriptor = new EditCommand.EditBugDescriptor(DESC_PARSER);
+        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG, copyDescriptor,
+            new State("todo"));
+        assertTrue(standardCommand.equals(commandWithSameValues));
+
+        // same object -> returns true
+        assertTrue(standardCommand.equals(standardCommand));
+
+        // null -> returns false
+        assertFalse(standardCommand.equals(null));
+
+        // different types -> returns false
+        assertFalse(standardCommand.equals(new ClearCommand()));
+
+        // normal EditCommand -> false
+        final EditCommand editCommand = new EditCommand(INDEX_FIRST_BUG, DESC_PARSER);
+        assertFalse(standardCommand.equals(editCommand));
+
+        // different index -> returns false
+        assertFalse(standardCommand.equals(new EditByStateCommand(INDEX_SECOND_BUG, DESC_PARSER, new State("todo"))));
+
+        // different descriptor -> returns false
+        assertFalse(standardCommand.equals(new EditByStateCommand(INDEX_FIRST_BUG, DESC_HOMEPAGE, new State("todo"))));
+
+        // different target state -> false
+        assertFalse(standardCommand.equals(new EditByStateCommand(INDEX_FIRST_BUG, DESC_PARSER, new State("backlog"))));
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/EditByStateCommandTest.java
@@ -3,10 +3,7 @@ package seedu.address.logic.commands;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.commons.core.Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_HOMEPAGE;
-import static seedu.address.logic.commands.CommandTestUtil.DESC_PARSER;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_NAME_HOMEPAGE;
-import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.*;
 import static seedu.address.testutil.Assert.assertThrows;
 import static seedu.address.testutil.TypicalBugs.getTypicalKanBugTracker;
 import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BUG;
@@ -33,10 +30,6 @@ public class EditByStateCommandTest {
             new EditBugDescriptorBuilder().withName(VALID_NAME_HOMEPAGE).build(), new State("backlog"));
         assertThrows(CommandException.class, MESSAGE_INVALID_BUG_DISPLAYED_INDEX, ()-> editByStateCommandBacklog
                                                                                            .execute(model));
-        EditByStateCommand editByStateCommandOngoing = new EditByStateCommand(INDEX_SECOND_BUG,
-            new EditBugDescriptorBuilder().withName(VALID_NAME_HOMEPAGE).build(), new State("done"));
-        assertThrows(CommandException.class, MESSAGE_INVALID_BUG_DISPLAYED_INDEX, ()-> editByStateCommandOngoing
-                                                                                           .execute(model));
     }
 
     @Test
@@ -56,12 +49,9 @@ public class EditByStateCommandTest {
     @Test
     public void equals() {
         final EditByStateCommand standardCommand = new EditByStateCommand(INDEX_FIRST_BUG,
-                            DESC_PARSER, new State("todo"));
-
-        // same values -> returns true
+                            DESC_PARSER, VALID_STATE_BUG1);
         EditCommand.EditBugDescriptor copyDescriptor = new EditCommand.EditBugDescriptor(DESC_PARSER);
-        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG, copyDescriptor,
-            new State("todo"));
+        EditByStateCommand commandWithSameValues = new EditByStateCommand(INDEX_FIRST_BUG, copyDescriptor, new State("todo"));
         assertTrue(standardCommand.equals(commandWithSameValues));
 
         // same object -> returns true

--- a/src/test/java/seedu/address/logic/commands/KanbanCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/KanbanCommandTest.java
@@ -1,0 +1,19 @@
+package seedu.address.logic.commands;
+
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+
+public class KanbanCommandTest {
+    private Model model = new ModelManager();
+    private Model expectedModel = new ModelManager();
+
+    @Test
+    public void execute_kanban_success() {
+        CommandResult expectedCommandResult = new CommandResult("", false, false, true);
+        assertCommandSuccess(new KanbanCommand(), model, expectedCommandResult, expectedModel);
+    }
+}

--- a/src/test/java/seedu/address/logic/commands/MoveByStateCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MoveByStateCommandTest.java
@@ -1,0 +1,83 @@
+package seedu.address.logic.commands;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_BUG1;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_BUG2;
+import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_PARSER;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
+import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;
+import static seedu.address.logic.commands.CommandTestUtil.showBugAtIndex;
+import static seedu.address.testutil.TypicalBugs.getTypicalKanBugTracker;
+import static seedu.address.testutil.TypicalIndexes.INDEX_FIRST_BUG;
+import static seedu.address.testutil.TypicalIndexes.INDEX_SECOND_BUG;
+
+import org.junit.jupiter.api.Test;
+
+import seedu.address.commons.core.Messages;
+import seedu.address.commons.core.index.Index;
+import seedu.address.model.KanBugTracker;
+import seedu.address.model.Model;
+import seedu.address.model.ModelManager;
+import seedu.address.model.UserPrefs;
+import seedu.address.model.bug.Bug;
+import seedu.address.testutil.BugBuilder;
+
+public class MoveByStateCommandTest {
+
+    private Model model = new ModelManager(getTypicalKanBugTracker(), new UserPrefs());
+
+    @Test
+    public void execute_invalidBugIndexUnfilteredListTodo_failure() {
+        Index outOfBoundIndex = Index.fromOneBased(model.getFilteredBugListByState(VALID_STATE_BUG1).size() + 1);
+        MoveByStateCommand moveCommand = new MoveByStateCommand(outOfBoundIndex, VALID_STATE_BUG1, VALID_STATE_BUG2);
+        assertCommandFailure(moveCommand, model, Messages.MESSAGE_INVALID_BUG_DISPLAYED_INDEX);
+    }
+
+    @Test
+    public void execute_filteredList_success() {
+        showBugAtIndex(model, INDEX_SECOND_BUG);
+
+        Bug bugInFilteredList = model.getFilteredBugListByState(VALID_STATE_BUG1).get(INDEX_FIRST_BUG.getZeroBased());
+        Bug movedBug = new BugBuilder(bugInFilteredList).withState(VALID_STATE_PARSER).build();
+        MoveByStateCommand moveCommand = new MoveByStateCommand(INDEX_FIRST_BUG, movedBug.getState(), VALID_STATE_BUG1);
+
+        String expectedMessage = String.format(MoveCommand.MESSAGE_MOVE_BUG_SUCCESS, movedBug);
+
+        Model expectedModel = new ModelManager(new KanBugTracker(model.getKanBugTracker()), new UserPrefs());
+        expectedModel.setBug(model.getFilteredBugListByState(VALID_STATE_BUG1).get(0),
+            movedBug);
+
+        assertCommandSuccess(moveCommand, model, expectedMessage, expectedModel);
+    }
+
+
+    @Test
+    public void equals() {
+        MoveByStateCommand command = new MoveByStateCommand(INDEX_FIRST_BUG, VALID_STATE_BUG1, VALID_STATE_BUG2);
+        MoveByStateCommand sameCommand = new MoveByStateCommand(INDEX_FIRST_BUG, VALID_STATE_BUG1,
+            VALID_STATE_BUG2);
+
+        //same object -> true
+        assertTrue(command.equals(command));
+
+        //same items -> true
+        assertTrue(command.equals(sameCommand));
+
+        //null -> false
+        assertFalse(command.equals(null));
+
+        //different command
+        assertFalse(command.equals(new ExitCommand()));
+
+        //different index
+        assertFalse(command.equals(new MoveByStateCommand(INDEX_SECOND_BUG, VALID_STATE_BUG1, VALID_STATE_BUG2)));
+
+        //different new state
+        assertFalse(command.equals(new MoveByStateCommand(INDEX_FIRST_BUG, VALID_STATE_BUG2,
+            VALID_STATE_BUG1)));
+
+        //different target state
+        assertFalse(command.equals(new MoveByStateCommand(INDEX_FIRST_BUG, VALID_STATE_BUG1, VALID_STATE_BUG1)));
+    }
+}


### PR DESCRIPTION
In this PR I added the ability to move and edit bugs according to the state. This would be important for the Kannan window as bugs are displayed by state. The prefix chosen is c/ as c stands for column. 

An example for the move command would be move 1 s/todo c/backlog which would move the first bug in backlog to the state of todo.

The c/ prefix is optional at this point as we have not decided if we want to remove the MainWindow from the application.