### PR TITLE
Fix bug displaying wrong message for move command

### DIFF
--- a/src/main/java/seedu/address/logic/commands/MoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveCommand.java
@@ -26,7 +26,8 @@ public class MoveCommand extends Command {
             + PREFIX_STATE + "done";
 
     public static final String MESSAGE_MOVE_BUG_SUCCESS = "Moved Bug: %1$s";
-    public static final String MESSAGE_DUPLICATE_BUG = "This bug already exists in the KanBug Tracker.";
+    public static final String MESSAGE_DUPLICATE_STATE =
+            "Cannot move bug to the same state. Please try another state instead!";
 
     protected final Index index;
     protected final State state;
@@ -65,7 +66,7 @@ public class MoveCommand extends Command {
         Bug movedBug = createMovedBug(bugToMove, state);
 
         if (model.hasBug(movedBug)) {
-            throw new CommandException(MESSAGE_DUPLICATE_BUG);
+            throw new CommandException(MESSAGE_DUPLICATE_STATE);
         }
 
         model.setBug(bugToMove, movedBug);

--- a/src/test/java/seedu/address/logic/commands/MoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MoveCommandTest.java
@@ -84,7 +84,7 @@ class MoveCommandTest {
 
         MoveCommand moveCommand = new MoveCommand(Index.fromZeroBased(1), bugInList.getState());
 
-        assertCommandFailure(moveCommand, model, MoveCommand.MESSAGE_DUPLICATE_BUG);
+        assertCommandFailure(moveCommand, model, MoveCommand.MESSAGE_DUPLICATE_STATE);
     }
 
     @Test


### PR DESCRIPTION
closes #195 
What I have done in this PR:
- Fix bug displaying wrong message for move command when the user moves a bug to the same state