### PR TITLE
Change Bug#isSameBug to compare only the name.

### DIFF
--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -136,7 +136,7 @@ Let's look at the various parts of a bug to understand how they are represented 
 
 #### 1 - Bug Name
 
-You get to choose what you want to name each bug you enter into the KanBug Tracker.
+You get to choose what you want to name each bug you enter into the KanBug Tracker. No two bugs can have the same name.
 
 #### 2 - Priority
 
@@ -245,6 +245,7 @@ Format: `add n/NAME d/DESCRIPTION [s/STATE] [note/NOTE] [t/TAG] [pr/PRIORITY]`
 - Add a bug with the specified name, description and state to the bottom of the list.
 - The state, note and tag fields are optional, all other fields are needed.
 - If state is not specified, a default state of backlog will be assigned.
+- The command will fail if a bug with the same name already exists.
 
 Examples:
 
@@ -284,6 +285,7 @@ Format: `edit INDEX [c/COLUMN] [n/NEW_NAME] [d/NEW_DESCRIPTION] [note/NEW_NOTE] 
 - At least one of the optional fields must be provided.
 - Existing values will be updated to the input values.
 - **Multiple tags** can be added or edited.
+- The command will fail if the operation results in duplicated bugs (bugs with the same name).
 
 Examples:
 
@@ -344,6 +346,7 @@ Format: `move INDEX [c/COLUMN] s/STATE`
 - State can either be **backlog, todo, ongoing** or **done**.
 - If the "destination" state is the same with the initial state of the bug, no change will be made.
 - The bug must exist to be moved (e.g. we cannot move the fifth bug in the List view if there are only four bugs).
+
 Examples:
 
 - `move 1 s/todo`, moves the first bug in the List view from its initial state to the “Todo” state.

--- a/src/main/java/seedu/address/logic/commands/MoveCommand.java
+++ b/src/main/java/seedu/address/logic/commands/MoveCommand.java
@@ -64,10 +64,6 @@ public class MoveCommand extends Command {
         Bug bugToMove = lastShownList.get(index.getZeroBased());
         Bug movedBug = createMovedBug(bugToMove, state);
 
-        if (model.hasBug(movedBug)) {
-            throw new CommandException(MESSAGE_DUPLICATE_BUG);
-        }
-
         model.setBug(bugToMove, movedBug);
         model.updateFilteredBugList(PREDICATE_SHOW_ALL_BUGS);
 

--- a/src/main/java/seedu/address/model/bug/Bug.java
+++ b/src/main/java/seedu/address/model/bug/Bug.java
@@ -68,7 +68,7 @@ public class Bug {
     }
 
     /**
-     * Returns true if both bugs of the same name have at least one other identity field that is the same.
+     * Returns true if both bugs have the same name.
      * This defines a weaker notion of equality between two bugs.
      */
     public boolean isSameBug(Bug otherBug) {
@@ -77,8 +77,7 @@ public class Bug {
         }
 
         return otherBug != null
-                && otherBug.getName().equals(getName())
-                && otherBug.getState().equals(getState());
+                && otherBug.getName().equals(getName());
     }
 
     /**

--- a/src/test/java/seedu/address/logic/commands/MoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MoveCommandTest.java
@@ -4,7 +4,6 @@ import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_BUG1;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_BUG2;
-import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_HOMEPAGE;
 import static seedu.address.logic.commands.CommandTestUtil.VALID_STATE_PARSER;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandFailure;
 import static seedu.address.logic.commands.CommandTestUtil.assertCommandSuccess;

--- a/src/test/java/seedu/address/logic/commands/MoveCommandTest.java
+++ b/src/test/java/seedu/address/logic/commands/MoveCommandTest.java
@@ -70,24 +70,6 @@ class MoveCommandTest {
     }
 
     @Test
-    public void execute_createDuplicateBugs_failure() {
-        Bug bugInList = model.getFilteredBugList().get(INDEX_FIRST_BUG.getZeroBased());
-
-        // make sure that this bug is different from a bug in the model only in state
-        Bug bugWithDifferentState = new BugBuilder(bugInList)
-                .withState(bugInList.getState().getStringOfValue().equals(VALID_STATE_HOMEPAGE)
-                        ? VALID_STATE_PARSER : VALID_STATE_HOMEPAGE).build();
-
-        // set the 2nd bug as the bugWithDifferentState
-        Model newModel = new ModelManager(new KanBugTracker(model.getKanBugTracker()), new UserPrefs());
-        newModel.setBug(model.getFilteredBugList().get(1), bugWithDifferentState);
-
-        MoveCommand moveCommand = new MoveCommand(Index.fromZeroBased(1), bugInList.getState());
-
-        assertCommandFailure(moveCommand, model, MoveCommand.MESSAGE_DUPLICATE_BUG);
-    }
-
-    @Test
     public void equals() {
         final MoveCommand standardCommand = new MoveCommand(INDEX_FIRST_BUG, VALID_STATE_BUG1);
 

--- a/src/test/java/seedu/address/model/bug/BugTest.java
+++ b/src/test/java/seedu/address/model/bug/BugTest.java
@@ -34,20 +34,17 @@ public class BugTest {
         // null -> returns false
         assertFalse(BUGONE.isSameBug(null));
 
-        // different state -> returns false
-        Bug editedBugOne = new BugBuilder(BUGONE).withState(VALID_STATE_HOMEPAGE).build();
-        assertFalse(BUGONE.isSameBug(editedBugOne));
-
         // different name -> returns false
-        editedBugOne = new BugBuilder(BUGONE).withName(VALID_NAME_HOMEPAGE).build();
+        Bug editedBugOne = new BugBuilder(BUGONE).withName(VALID_NAME_HOMEPAGE).build();
         assertFalse(BUGONE.isSameBug(editedBugOne));
 
-        // same name, same state, different attributes -> returns true
-        editedBugOne = new BugBuilder(BUGONE).withDescription(VALID_DESCRIPTION_HOMEPAGE)
-                .withTags(VALID_TAG_COMPONENT).withPriority(VALID_PRIORITY_HOMEPAGE).build();
+        // same name, different attributes -> returns true
+        editedBugOne = new BugBuilder(BUGONE).withState(VALID_STATE_HOMEPAGE)
+                .withDescription(VALID_DESCRIPTION_HOMEPAGE).withTags(VALID_TAG_COMPONENT)
+                .withPriority(VALID_PRIORITY_HOMEPAGE).build();
         assertTrue(BUGONE.isSameBug(editedBugOne));
 
-        // same name, state and attributes -> returns true
+        // same name and attributes -> returns true
         editedBugOne = new BugBuilder(BUGONE).build();
         assertTrue(BUGONE.isSameBug(editedBugOne));
     }


### PR DESCRIPTION
Fix #214, #179 
- Bug with the same name but different states now will be considered as the same bug. Thus moving a bug to a new state doesn't need to check if the target state has a bug with the same name (relating to PR #156) since every bug must have different names, to begin with.
- Update related tests.
- Update UG in 2.1, 3.5, 3.7 to reflect the change.