### PR TITLE
Fix minor bugs & Update UG

### DIFF
--- a/docs/DeveloperGuide.md
+++ b/docs/DeveloperGuide.md
@@ -669,7 +669,7 @@ testers are expected to do more *exploratory* testing.
     1. Close the `help` window using the mouse<br>
        Expected: only the `help` window will be closed.
     
-1. Test case 2 (for Windows users only):
+1. Test case 2:
 
     1. Switch to List View.
     

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -293,6 +293,9 @@ Just type `help` and hit `Enter`
 
 This creates a popup (the Help Window) with a command guide that you can refer to.
 
+<div markdown="span" class="alert alert-success">:bulb: Tip: You can also press the F1 key to open the Help window. Try it!
+</div>
+
 ### 5.3 Listing all bugs : `list`
 
 After running the search command you might want to see all the bugs you have in your Kanbug Tracker at one glance. Thats where the `list` can be used.
@@ -376,7 +379,7 @@ Once the command has been entered, the result display shows the result of your c
 
 Made a mistake when adding in a bug or simply changed your mind on what the description should be? Fret not, that's what the edit command is for.
 
-Format: `edit INDEX (c/COLUMN) [n/NEW_NAME] [d/NEW_DESCRIPTION] [s/NEW_STATE] [note/NEW_NOTE] [t/NEW_TAG] [pr/NEW_PRIORITY]`
+Format: `edit INDEX (c/COLUMN) [n/NEW_NAME] [d/NEW_DESCRIPTION] [note/NEW_NOTE] [t/NEW_TAG] [pr/NEW_PRIORITY]`
 
 - Edits the specified bug.
 - At least one of the optional fields must be provided.
@@ -493,7 +496,9 @@ Format: `exit`
 (Any parameters entered are ignored)
 
 When you are done with managing your tasks, use this command to saves all of the local data and exit from the app. 
-Alternatively, you can also close the window directly or press Esc key, and the app will do the same thing.
+
+<div markdown="span" class="alert alert-success">:bulb: Tip: You can also press the Esc key to close the window. Try it!
+</div>
 
 ### 5.13 Saving the data : automatically
 
@@ -510,7 +515,7 @@ Data is saved into the hard disk every time a change is made.
 | **search**  |                      `search q/QUERYSTRING`                  |
 |   **add**   |   `add n/NAME d/DESCRIPTION [s/STATE] [note/NOTE] [t/TAG] [pr/PRIORITY]`   |
 | **delete**  |                        `delete INDEX (c/COLUMN)`                        |
-|  **edit**   | `edit INDEX (c/COLUMN) [n/NEW_NAME] [d/NEW_DESCRIPTION] [s/NEW_STATE] [note/NEW_NOTE] [t/NEW_TAG] [pr/NEW_PRIORITY]` |
+|  **edit**   | `edit INDEX (c/COLUMN) [n/NEW_NAME] [d/NEW_DESCRIPTION] [note/NEW_NOTE] [t/NEW_TAG] [pr/NEW_PRIORITY]` |
 | **editTag** |       `editTag INDEX (c/COLUMN) ot/OLD_TAG nt/NEW_TAG`       |
 | **addTag**  |             `addTag INDEX (c/COLUMN) nt/NEW_TAG`             |
 |  **move**   |               `move INDEX (c/COLUMN) s/STATE`                |

--- a/docs/UserGuide.md
+++ b/docs/UserGuide.md
@@ -250,8 +250,8 @@ Some commands require the use of prefixes to indicate user input. Every command 
 Eg. <code>edit 1 n/firstname n/secondname</code> will result in the name of Bug 1 being editted to <b>secondname</b>.
 </div>
 
-<div markdown="span" class="alert alert-warning">:warning: WARNING: Using a prefix inside another prefix will result in it not being recognised by the application.
-Eg. <code>d/t/Location</code> will result in the description field of the Bug being set to <code>t/Location</code>. 
+<div markdown="span" class="alert alert-warning">:warning: WARNING: A prefix is only valid if it is preceded by a whitespace and is mentioned in the command syntax, otherwise it is treated as a normal string.
+Eg. <code>d/t/Location v/not a prefix</code> will result in the description field of the Bug being set to <code>t/Location v/not a prefix</code> because neither "t/" nor "v/" is considered as a prefix. 
 </div>
 
 ## 5. Features
@@ -260,6 +260,10 @@ Eg. <code>d/t/Location</code> will result in the description field of the Bug be
 - Items in `[...]` are **optional**
 - Items in `(...)` are only required in **KanBan view** and should not be supplied in **List view**
 - `INDEX` **must be a positive integer** 1,2,3...
+
+<div markdown="span" class="alert alert-warning">:warning: WARNING: For the prefixes surrounded by the parentheses in the command format, they are still considered as a valid prefix in List view even if they should not be supplied there.
+Eg. Executing <code>edit 1 d/column c/todo</code> in List view will not result in the description field of the Bug being set to <code>column c/todo</code> but will result in an error because "c/" is considered as a prefix and also which should not be supplied in List view. 
+</div>
 
 ### 5.1 Switching Views : `switch`
 

--- a/src/main/java/seedu/address/logic/commands/EditCommand.java
+++ b/src/main/java/seedu/address/logic/commands/EditCommand.java
@@ -54,7 +54,8 @@ public class EditCommand extends Command {
             + PREFIX_STATE + "todo";
 
     public static final String MESSAGE_EDIT_BUG_SUCCESS = "Edited Bug: %1$s";
-    public static final String MESSAGE_NOT_EDITED = "At least one field to edit must be provided.";
+    public static final String MESSAGE_NOT_EDITED =
+            "At least one field to edit must be provided and different from the original one.";
     public static final String MESSAGE_DUPLICATE_BUG = "This bug already exists in the KanBug Tracker.";
 
     protected final Index index;
@@ -87,6 +88,10 @@ public class EditCommand extends Command {
 
         Bug bugToEdit = lastShownList.get(index.getZeroBased());
         Bug editedBug = createEditedBug(bugToEdit, editBugDescriptor);
+
+        if (bugToEdit.equals(editedBug)) {
+            throw new CommandException(MESSAGE_NOT_EDITED);
+        }
 
         if (!bugToEdit.isSameBug(editedBug) && model.hasBug(editedBug)) {
             throw new CommandException(MESSAGE_DUPLICATE_BUG);

--- a/src/main/java/seedu/address/logic/parser/EditCommandParser.java
+++ b/src/main/java/seedu/address/logic/parser/EditCommandParser.java
@@ -42,7 +42,7 @@ public class EditCommandParser implements Parser<EditCommand> {
      */
     public EditCommand parse(String args) throws ParseException {
         requireNonNull(args);
-        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME, PREFIX_STATE,
+        ArgumentMultimap argMultimap = ArgumentTokenizer.tokenize(args, PREFIX_NAME,
                 PREFIX_DESCRIPTION, PREFIX_NOTE, PREFIX_TAG, PREFIX_PRIORITY, PREFIX_COLUMN);
 
         Index index;


### PR DESCRIPTION
- Disable moving bug using `edit`.
- Disable editing a bug without actually changing anything (the supplied fields are the same as the original ones).
- Add more warnings regarding the use of prefixes in UG.
- Add tips on the use of shortcut keys for `help` and `exit`